### PR TITLE
refactor: Change data format for popupInfo

### DIFF
--- a/src/components/KanbanBoard/TaskCard.tsx
+++ b/src/components/KanbanBoard/TaskCard.tsx
@@ -146,7 +146,7 @@ export function TaskCard({ task, className }: TaskCardProps) {
                                     </div>
                                 </div>
 
-                                {task.ai.summary && (
+                                { task.ai.popupInfo && (
                                     <Popover
                                         open={showAiInfo}
                                         onOpenChange={setShowAiInfo}
@@ -174,41 +174,30 @@ export function TaskCard({ task, className }: TaskCardProps) {
                                             <div className="font-bold text-sm">
                                                 {/* Display popupInfo data */}
                                                 {task.ai.popupInfo &&
-                                                    Object.keys(
-                                                        task.ai.popupInfo
-                                                    ).length > 0 && (
-                                                        <div className="space-y-2">
-                                                            {Object.entries(
-                                                                task.ai
-                                                                    .popupInfo
-                                                            ).map(
-                                                                ([
-                                                                    key,
-                                                                    value
-                                                                ]) => (
-                                                                    <div
-                                                                        key={
-                                                                            key
-                                                                        }
-                                                                        className="flex items-center gap-2 text-sm"
-                                                                    >
-                                                                        <div className="text-gray-700">
-                                                                            <span className="font-medium">
-                                                                                {
-                                                                                    key
-                                                                                }
-
-                                                                                :
-                                                                            </span>{" "}
-                                                                            {renderPopupInfoValue(
-                                                                                value
-                                                                            )}
-                                                                        </div>
-                                                                    </div>
-                                                                )
-                                                            )}
+                                                Array.isArray(task.ai.popupInfo) &&
+                                                task.ai.popupInfo.length > 0 && (
+                                                    <div className="space-y-2">
+                                                    {task.ai.popupInfo.map((item, index) => {
+                                                        // 각 객체에서 첫 번째 키-값 쌍 가져오기
+                                                        const key = Object.keys(item)[0];
+                                                        const value = item[key];
+                                                        
+                                                        return (
+                                                        <div
+                                                            key={index}
+                                                            className="flex items-center gap-2 text-sm"
+                                                        >
+                                                            <div className="text-gray-700">
+                                                            <span className="font-medium">
+                                                                {key}:
+                                                            </span>{" "}
+                                                            {renderPopupInfoValue(value)}
+                                                            </div>
                                                         </div>
-                                                    )}
+                                                        );
+                                                    })}
+                                                    </div>
+                                                )}
                                             </div>
                                         </PopoverContent>
                                     </Popover>

--- a/src/mocks/mockData.ts
+++ b/src/mocks/mockData.ts
@@ -42,10 +42,10 @@ export const mockTasks: Task[] = [
             topic: "AI Topic",
             summary:
                 "AI summary, simply dummy text of the printing and typesetting industry.",
-            popupInfo: {
-                "Lecture Time": { startTime: "11:50", endTime: "12:50" },
-                "QA Session": { duration: "20 minutes" }
-            }
+            popupInfo: [
+                {"Lecture Time": "11:50 ~ 12:50" },
+                {"QA Session": "20 minutes"}
+            ]
         }
     },
 
@@ -98,11 +98,11 @@ export const mockTasks: Task[] = [
         ai: {
             topic: "입사 면접",
             summary: "오후 2시에 오프라인 면접으로 가능할까요?",
-            popupInfo: {
-                "면접 일시": { date: "2025-02-03", time: "14:00" },
-                "면접 장소": { location: "본사 3층 회의실" },
-                면접관: { name: "박지원", department: "개발팀" }
-            }
+            popupInfo: [
+                { "면접 일시": "2025-02-03 14:00" },
+                { "면접 장소": "본사 3층 회의실" },
+                { "면접관": "박지원 개발실" }
+            ]
         }
     }
 ];


### PR DESCRIPTION
For popupInfo, only key-value pairs are possible, and keys can be duplicated. 
Therefore, I converted it to an Array.

`
ai: {
    topic: "입사 면접",
    summary: "오후 2시에 오프라인 면접으로 가능할까요?",
    popupInfo: [
        { "면접 일시": "2025-02-03 14:00" },
        { "면접 장소": "본사 3층 회의실" },
        { "면접관": "박지원 개발실" }
    ]
}
`