### PR TITLE
feat: add undoDelete API

### DIFF
--- a/src/hooks/api/om-native.d.ts
+++ b/src/hooks/api/om-native.d.ts
@@ -8,6 +8,7 @@ interface OMNative {
     openSchedule(scheduleId: string): Promise<void>;
     deleteSchedule(scheduleId: string, callback: (success: boolean) => void): boolean;
     getSchedules(callback: (json: string) => void): boolean;
+    undoDelete(itemId:string);
 }
 
 declare interface Window {


### PR DESCRIPTION
Added the undoDelete API. When called, this API triggers clearStatus on the server to restore the previous status.