### PR TITLE
Schedule API update: AI field, filter, and delete method stubs

### DIFF
--- a/src/hooks/api/om-native.d.ts
+++ b/src/hooks/api/om-native.d.ts
@@ -7,7 +7,7 @@ interface OMNative {
     openContact(name?: string, email: string): Promise<void>;
     openSchedule(scheduleId: string): Promise<void>;
     deleteSchedule(scheduleId: string, callback: (success: boolean) => void): boolean;
-    getSchedules(callback: (json: string) => void): boolean;
+    getSchedules(filters: string, callback: (json: string) => void): boolean;
     undoDelete(itemId:string);
 }
 

--- a/src/hooks/api/om-native.d.ts
+++ b/src/hooks/api/om-native.d.ts
@@ -9,6 +9,9 @@ interface OMNative {
     deleteSchedule(scheduleId: string, callback: (success: boolean) => void): boolean;
     getSchedules(filters: string, callback: (json: string) => void): boolean;
     undoDelete(itemId:string);
+    
+    deleteTaskByFilter(filters: string, callback: (success: boolean) => void): boolean;
+    deleteScheduleByIds(ids: string[], callback: (success: boolean) => void): boolean;
 }
 
 declare interface Window {

--- a/src/services/schedules.ts
+++ b/src/services/schedules.ts
@@ -31,8 +31,17 @@ import type { ScheduleDay } from "@/types/schedule";
  * @returns A promise resolving to an array of ScheduleDay objects representing daily schedules.
  */
 export async function fetchSchedules(): Promise<ScheduleDay[]> {
+    const filtersJson = JSON.stringify({
+        assignee: [],
+        startDate: "",
+        endDate: "",
+        categories:  [],
+        page: 0,
+        limit: 20
+    });
+
     const json = await new Promise<string>((resolve) => {
-        window.OMNative.getSchedules((json) => {
+        window.OMNative.getSchedules(filtersJson ,(json) => {
             resolve(json);
         });
     });

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -8,6 +8,11 @@ export interface Schedule {
     attendees: Address[];
     type: "past" | "future";
     location?: string;
+    ai?: {
+        topic?: string;
+        summary?: string;
+        popupInfo?: object;
+    };
 }
 
 export interface ScheduleDay {


### PR DESCRIPTION
Added ai field to Schedule model
Added filter support to getSchedule API
Added method stubs: deleteTaskByFilter, deleteScheduleByIds (implementation pending)
(Deletion methods are currently placeholders; logic will be implemented in a future PR.)
