### PR TITLE
feat: Change batch delete return value and add emailId to task/schedule

### DIFF
--- a/src/hooks/api/om-native.d.ts
+++ b/src/hooks/api/om-native.d.ts
@@ -10,8 +10,8 @@ interface OMNative {
     getSchedules(filters: string, callback: (json: string) => void): boolean;
     undoDelete(itemId:string);
     
-    deleteTaskByFilter(filters: string, callback: (success: boolean) => void): boolean;
-    deleteScheduleByIds(ids: string[], callback: (success: boolean) => void): boolean;
+    deleteTaskByFilter(filters: string, callback: (success: string) => void): boolean;
+    deleteScheduleByIds(ids: string[], callback: (success: string) => void): boolean;
 }
 
 declare interface Window {

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -7,6 +7,7 @@ export interface Schedule {
     title: string;
     startTime: string;
     endTime: string;
+    emailId:string;
     attendees: Address[];
     type: "past" | "future";
     location?: string;

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -11,6 +11,7 @@ export interface Task {
     allowEdit?: boolean;
     categories?: string;
     assignedMe: boolean;
+    emailId:string;
     ai?: {
         topic?: string;
         summary?: string;


### PR DESCRIPTION
The return value of task/schedule has been changed from true/false to a JSON array to support batch processing.

The returned JSON format is as follows:
```
[
  {
    "id": "100_1_0",
    "result": true,
    "errorReason": null
  },
  {
    "id": "100_2_0",
    "result": false,
    "errorReason": "Failed .."
  }
]
```